### PR TITLE
bunch of additional commentary

### DIFF
--- a/aws.dis
+++ b/aws.dis
@@ -84,14 +84,14 @@ HD_STATUS    EQU  3h	; read only (chip 6A)
 ;
 ; We can write the following, starting with the LSB:
 ;
-;  UD7 - RDGATE+
-;  UD6 - BOZ+
-;  UD5 - WRTOP+
-;  UD4 - CRCTINE+
-;  UD3 - CRCRST+
-;  UD2 - DMARQ+
-;  UD1 - INT6+
-;  UD0 - REDWC*
+;  UD7 - RDGATE+	driv[0]
+;  UD6 - 8OZ+		driv[1]
+;  UD5 - WRTOP+		driv[2]
+;  UD4 - CRCTIME+	driv[3]
+;  UD3 - CRCRST+	driv[4]
+;  UD2 - DMARQ+		driv[5]
+;  UD1 - INT6+		driv[6]
+;  UD0 - REDWC*		driv[7]
 ;
 ; ----------------------------------------------------------
 ; Lastly consider the device at chip location 6A that we only read.
@@ -103,10 +103,10 @@ HD_STATUS    EQU  3h	; read only (chip 6A)
 ; Then the signals available on this chip are,
 ; starting with the LSB:
 ;
-;  UD7 - GAPDET*
-;  UD6 - 16Z+
-;  UD5 - AM+
-;  UD4 - REQ+
+;  UD7 - GAPDET*	sriv[0]
+;  UD6 - 16Z+		sriv[1]
+;  UD5 - AM+		sriv[2]
+;  UD4 - REQ+		sriv[3]
 ;  UD3 - DRTYPE0-	sriv[4]
 ;  UD2 - FULL*		sriv[5]
 ;  UD1 - DMACK*		sriv[6]
@@ -125,10 +125,10 @@ FLAG1        EQU  31h	; flag register 1 -- 0x8e (holds handshake bit)
 STATUS       EQU  32h	; CPU sees this at 0x8d (status)
 IO3          EQU  33h	; - used indirectly for FD
 IO4          EQU  34h	; - used indirectly for HD
-IO5          EQU  35h	; - never used
-IO6          EQU  36h	; - never used
-IO7          EQU  37h	; - never used
-IO8          EQU  38h	; - never used
+IO5          EQU  35h	; - used indirectly for FD
+IO6          EQU  36h	; - used indirectly for HD
+IO7          EQU  37h	; - used indirectly for FD
+IO8          EQU  38h	; - used indirectly for HD
 IO9          EQU  39h	; - never used
 IOa          EQU  3ah	; - never used
 IOb          EQU  3bh	; CPU sees this at 0x84
@@ -145,11 +145,11 @@ DMA          EQU  3fh	; CPU sees this at 0x80 (DMA data)
 ; the VAL registers serve as "scratch space" for the 8x300
 ; (this is a 16 item "register file"
 
-VAL_0        EQU  48h	; used "indirectly"
-VAL_1        EQU  49h	; used "indirectly"
+VAL_0        EQU  48h	; used "indirectly" for FD
+VAL_1        EQU  49h	; used "indirectly" for HD
 VAL_2        EQU  4ah
 VAL_3        EQU  4bh
-VAL_4        EQU  4ch
+VAL_4        EQU  4ch	; track number
 VAL_5        EQU  4dh
 VAL_6        EQU  4eh
 VAL_7        EQU  4fh
@@ -167,12 +167,26 @@ CSR2         EQU  5bh
 CSR3         EQU  5ch
 CSR4         EQU  5dh
 
+; CSR1
+;   driv[7]   = write gate enable (0 = enabled)
+;   driv[6:4] = crc enable, data reg control, sync enable
+;   sriv[1]   = byte transfer flag
+;   sriv[0]   = READY (disk status)
+
+; CSR2
+;   driv[7]   = precomp enable
+;   driv[6]   = read mode (0 = disk read, 1 = disk write, 1 and WG disabled, lock on to crystal osc for read)
+;   driv[5:4] = bit select (0 = bit cell 0)
+;   driv[3]   = preamble select
+;   driv[2:1] = FM/MFM (0 = MFM)
+;   driv[0]   = data rate frequency halver (0 = 250kbit in MFM)
+
 ; CSR3 has 7 bits (one bit is permanently zero)
 ; all are outputs.
 ;   driv[7] = DIR (for seek)
 ;   driv[6] = STEP (for seek)
-;   driv[5] = DS1 (selects floppy)
-;   driv[4] = DS2 (select hard drive)
+;   driv[5] = DS1 (selects hard drive or floppy 1)
+;   driv[4] = DS0 (selects floppy 0)
 ;   driv[3] = HDSEL2 (head)
 ;   driv[2] = HDSEL1 (head)
 ;   driv[1] = HDSEL0 (head)
@@ -201,9 +215,9 @@ FDC_DATA     EQU  5fh
 ; Next we do a bunch of initialization.
 
 0002: cf 5a x0002:  xmit    CSR1,ivr
-0003: d8 21         xmit    1h,driv[7]
+0003: d8 21         xmit    1h,driv[7]		; disable write gate
 0004: cf 5c         xmit    CSR3,ivr
-0005: db 40         xmit    0h,driv[5:4]
+0005: db 40         xmit    0h,driv[5:4]	; deselect drives
 0006: cf 30         xmit    FLAG0,ivr
 0007: c0 41         xmit    41h,aux
 0008: 00 1f         move    aux,driv		; FLAG0 = 0x41
@@ -221,7 +235,7 @@ FDC_DATA     EQU  5fh
 0014: cf 4a         xmit    VAL_2,ivr
 0015: 01 1f         move    r1,driv		; VAL_2 = 0
 0016: cf 5c         xmit    CSR3,ivr
-0017: d9 20         xmit    0h,driv[6]
+0017: d9 20         xmit    0h,driv[6]		; STEP = 0
 
 ; We branch here from several places below
 ;  (as well as dropping in from above
@@ -237,7 +251,7 @@ FDC_DATA     EQU  5fh
 001c: 00 1f         move    aux,driv		; CSR1 = 0xff
 001d: c0 40         xmit    40h,aux
 001e: cf 5b         xmit    CSR2,ivr
-001f: 00 1f         move    aux,driv		; CSR2 = 0x40
+001f: 00 1f         move    aux,driv		; CSR2 = 0x40 (mode: disk write)
 0020: cf 5f         xmit    FDC_DATA,ivr
 0021: 00 1f         move    aux,driv		; FDC_DATA = 0x40
 
@@ -290,7 +304,7 @@ FDC_DATA     EQU  5fh
 0042: e0 6a x0042:  jmp     x006a
 
 0043: cf 5c x0043:  xmit    CSR3,ivr
-0044: db 41         xmit    1h,driv[5:4]
+0044: db 41         xmit    1h,driv[5:4]	; select floppy
 
 ; Here is an interesting loop.  We read CSR1 twice and
 ; compare the reads.  We loop until the values differ.
@@ -299,11 +313,11 @@ FDC_DATA     EQU  5fh
 0046: 1f 21         move    sriv[0],r1
 0047: cf 5a         xmit    CSR1,ivr
 0048: 1f 20         move    sriv[0],aux
-0049: 61 00         xor     r1,aux
+0049: 61 00         xor     r1,aux		; waiting for READY to change
 004a: a0 45         nzt     aux,x0045
 
 004b: cf 5c         xmit    CSR3,ivr
-004c: db 42         xmit    2h,driv[5:4]
+004c: db 42         xmit    2h,driv[5:4]	; select hard drive
 
 ; again we loop waiting for a bit change.
 
@@ -311,11 +325,11 @@ FDC_DATA     EQU  5fh
 004e: 1f 22         move    sriv[0],r2
 004f: cf 5a         xmit    CSR1,ivr
 0050: 1f 20         move    sriv[0],aux
-0051: 62 00         xor     r2,aux
+0051: 62 00         xor     r2,aux		; waiting for READY to change
 0052: a0 4d         nzt     aux,x004d
 
 0053: cf 5c         xmit    CSR3,ivr
-0054: db 40         xmit    0h,driv[5:4]
+0054: db 40         xmit    0h,driv[5:4]	; deselect drives
 0055: c0 01         xmit    1h,aux
 0056: 61 01         xor     r1,r1
 0057: 62 02         xor     r2,r2
@@ -431,7 +445,7 @@ FDC_DATA     EQU  5fh
 00a6: cf 3e x00a6:  xmit    M_STATUS,ivr
 00a7: da 21         xmit    1h,driv[5]
 00a8: cf 02         xmit    HD_CMD,ivr
-00a9: d9 21         xmit    1h,driv[6]
+00a9: d9 21         xmit    1h,driv[6]		; INT6
 00aa: e7 a5         jmp     x07a5
 
 ; ---------------------------
@@ -522,10 +536,12 @@ FDC_DATA     EQU  5fh
 00dc: cf 3b x00dc:  xmit    IOb,ivr
 00dd: d8 20         xmit    0h,driv[7]
 00de: e7 a5         jmp     x07a5
+
 00df: e0 9e x00df:  jmp     x009e
 00e0: c5 00         xmit    0h,r5
 00e1: c5 01         xmit    1h,r5
 00e2: c5 00         xmit    0h,r5
+
 00e3: e0 9e x00e3:  jmp     x009e
 00e4: df 20         xmit    0h,driv[0]
 00e5: de 20         xmit    0h,driv[1]
@@ -557,7 +573,7 @@ FDC_DATA     EQU  5fh
 
 ; This starts the loop.
 00ee: c9 13 x00ee:  xmit    13h,r11		; r11 = 0x13 = 19
-00ef: e7 2f         jmp     x072f
+00ef: e7 2f         jmp     x072f		; output aux to STATUS reg
 
 00f0: c0 01 x00f0:  xmit    1h,aux		; aux = 1
 00f1: 21 01         add     r1,r1		; r1++
@@ -704,7 +720,7 @@ FDC_DATA     EQU  5fh
 014b: c1 00 x014b:  xmit    0h,r1		; r1 = 0
 014c: c0 48         xmit    48h,aux		; aux = 0x48
 014d: 25 0f         add     r5,ivr
-014e: 01 1f         move    r1,driv
+014e: 01 1f         move    r1,driv		; VAL_0 (FD) = 0 or VAL_1 (HD) = 0
 014f: e7 9d         jmp     x079d
 
 0150: e1 28 x0150:  jmp     x0128		; joins seek above
@@ -724,7 +740,7 @@ FDC_DATA     EQU  5fh
 
 0159: c1 40 x0159:  xmit    40h,r1
 015a: cf 5b         xmit    CSR2,ivr
-015b: 01 1f         move    r1,driv
+015b: 01 1f         move    r1,driv		; CSR2 = 0x40 (mode: disk write)
 015c: cf 5a         xmit    CSR1,ivr
 015d: db 66         xmit    6h,driv[6:4]
 015e: c1 4b         xmit    4bh,r1
@@ -750,7 +766,7 @@ FDC_DATA     EQU  5fh
 0170: cf 4b x0170:  xmit    VAL_3,ivr
 0171: 1b 60         move    sriv[6:4],aux
 0172: cf 5c         xmit    CSR3,ivr
-0173: 00 7e         move    aux,driv[3:1]
+0173: 00 7e         move    aux,driv[3:1]	; head select = VAL_3[6:4]
 0174: c9 1e         xmit    1eh,r11		; r11 = 0x1e = 30
 0175: e7 68         jmp     x0768
 0176: cf 02 x0176:  xmit    HD_CMD,ivr
@@ -759,23 +775,23 @@ FDC_DATA     EQU  5fh
 0179: dc 20         xmit    0h,driv[3]
 017a: dd 21         xmit    1h,driv[2]
 017b: cf 5a         xmit    CSR1,ivr
-017c: d8 20         xmit    0h,driv[7]
+017c: d8 20         xmit    0h,driv[7]		; enable write gate
 017d: c0 01         xmit    1h,aux
 017e: cf 4b         xmit    VAL_3,ivr
 017f: 1f 01         move    sriv,r1
 0180: cf 4c         xmit    VAL_4,ivr
-0181: 1f 02         move    sriv,r2
+0181: 1f 02         move    sriv,r2		; r2 = track number
 0182: cf 02         xmit    HD_CMD,ivr
-0183: da 21         xmit    1h,driv[5]
+0183: da 21         xmit    1h,driv[5]		; trigger DMA Request
 0184: da 20         xmit    0h,driv[5]
 0185: cf 03         xmit    HD_STATUS,ivr
-0186: b9 26 x0186:  nzt     sriv[6],x0186
-0187: b9 29 x0187:  nzt     sriv[6],x0189
+0186: b9 26 x0186:  nzt     sriv[6],x0186	; wait for DMA ACK
+0187: b9 29 x0187:  nzt     sriv[6],x0189	; wait for DMA ACK cleared
 0188: e1 87         jmp     x0187
 0189: cf 3f x0189:  xmit    DMA,ivr
-018a: 1f 03         move    sriv,r3
+018a: 1f 03         move    sriv,r3		; get byte from DMA
 018b: cf 02         xmit    HD_CMD,ivr
-018c: da 21         xmit    1h,driv[5]
+018c: da 21         xmit    1h,driv[5]		; trigger DMA Request
 018d: da 20         xmit    0h,driv[5]
 018e: cf 4f         xmit    VAL_7,ivr
 018f: 1f 04         move    sriv,r4
@@ -787,9 +803,9 @@ FDC_DATA     EQU  5fh
 0195: 05 1f         move    r5,driv
 0196: cf 5d x0196:  xmit    CSR4,ivr
 0197: b9 39         nzt     sriv[6],x0199
-0198: e1 96         jmp     x0196
+0198: e1 96         jmp     x0196		; waiting for INDEX
 0199: cf 5d x0199:  xmit    CSR4,ivr
-019a: b9 39         nzt     sriv[6],x0199
+019a: b9 39         nzt     sriv[6],x0199	; waiting for INDEX to clear
 019b: cf 03         xmit    HD_STATUS,ivr
 019c: bc 3c x019c:  nzt     sriv[3],x019c
 019d: cf 03 x019d:  xmit    HD_STATUS,ivr
@@ -803,7 +819,7 @@ FDC_DATA     EQU  5fh
 01a5: bc 25 x01a5:  nzt     sriv[3],x01a5
 01a6: cf 01         xmit    DATA_PORT,ivr
 01a7: c5 a1         xmit    0a1h,r5
-01a8: 05 1f         move    r5,driv
+01a8: 05 1f         move    r5,driv		; DATA_PORT = 0xa1
 01a9: cf 03         xmit    HD_STATUS,ivr
 01aa: bc 2a x01aa:  nzt     sriv[3],x01aa
 01ab: cf 02         xmit    HD_CMD,ivr
@@ -812,19 +828,19 @@ FDC_DATA     EQU  5fh
 01ae: bc 2e x01ae:  nzt     sriv[3],x01ae
 01af: cf 01         xmit    DATA_PORT,ivr
 01b0: c5 fe         xmit    0feh,r5
-01b1: 05 1f         move    r5,driv
+01b1: 05 1f         move    r5,driv		; DATA_PORT = 0xfe
 01b2: cf 03         xmit    HD_STATUS,ivr
 01b3: bc 33 x01b3:  nzt     sriv[3],x01b3
 01b4: cf 01         xmit    DATA_PORT,ivr
-01b5: 01 1f         move    r1,driv
+01b5: 01 1f         move    r1,driv		; DATA_PORT = r1
 01b6: cf 03         xmit    HD_STATUS,ivr
 01b7: bc 37 x01b7:  nzt     sriv[3],x01b7
 01b8: cf 01         xmit    DATA_PORT,ivr
-01b9: 02 1f         move    r2,driv
+01b9: 02 1f         move    r2,driv		; DATA_PORT = r2 (track number?)
 01ba: cf 03         xmit    HD_STATUS,ivr
 01bb: bc 3b x01bb:  nzt     sriv[3],x01bb
 01bc: cf 01         xmit    DATA_PORT,ivr
-01bd: 03 1f         move    r3,driv
+01bd: 03 1f         move    r3,driv		; DATA_PORT = r3
 01be: cf 03         xmit    HD_STATUS,ivr
 01bf: bc 3f x01bf:  nzt     sriv[3],x01bf
 01c0: cf 02         xmit    HD_CMD,ivr
@@ -833,7 +849,7 @@ FDC_DATA     EQU  5fh
 01c3: bc 23 x01c3:  nzt     sriv[3],x01c3
 01c4: cf 01         xmit    DATA_PORT,ivr
 01c5: c5 00         xmit    0h,r5
-01c6: 05 1f         move    r5,driv
+01c6: 05 1f         move    r5,driv		; DATA_PORT = 0
 01c7: cf 03         xmit    HD_STATUS,ivr
 01c8: bc 28 x01c8:  nzt     sriv[3],x01c8
 01c9: cf 02         xmit    HD_CMD,ivr
@@ -853,7 +869,7 @@ FDC_DATA     EQU  5fh
 01d7: bc 37 x01d7:  nzt     sriv[3],x01d7
 01d8: cf 01         xmit    DATA_PORT,ivr
 01d9: c5 a1         xmit    0a1h,r5
-01da: 05 1f         move    r5,driv
+01da: 05 1f         move    r5,driv		; DATA_PORT = 0xa1
 01db: cf 03         xmit    HD_STATUS,ivr
 01dc: bc 3c x01dc:  nzt     sriv[3],x01dc
 01dd: cf 02         xmit    HD_CMD,ivr
@@ -862,11 +878,11 @@ FDC_DATA     EQU  5fh
 01e0: bc 20 x01e0:  nzt     sriv[3],x01e0
 01e1: cf 01         xmit    DATA_PORT,ivr
 01e2: c5 f8         xmit    0f8h,r5
-01e3: 05 1f         move    r5,driv
+01e3: 05 1f         move    r5,driv		; DATA_PORT = 0xf8
 01e4: cf 03         xmit    HD_STATUS,ivr
 01e5: bc 25 x01e5:  nzt     sriv[3],x01e5
 01e6: cf 01         xmit    DATA_PORT,ivr
-01e7: 04 1f         move    r4,driv
+01e7: 04 1f         move    r4,driv		; DATA_PORT = r4
 01e8: cf 03 x01e8:  xmit    HD_STATUS,ivr
 01e9: bc 29 x01e9:  nzt     sriv[3],x01e9
 01ea: 26 06         add     r6,r6
@@ -887,13 +903,13 @@ FDC_DATA     EQU  5fh
 01f9: a9 fb         nzt     r11,x01fb
 01fa: e2 05         jmp     x0205
 01fb: cf 3f x01fb:  xmit    DMA,ivr
-01fc: 1f 03         move    sriv,r3
+01fc: 1f 03         move    sriv,r3		; get byte from DMA
 01fd: 29 00         add     r11,aux
 01fe: e7 a9         jmp     x07a9
 01ff: c0 01 x01ff:  xmit    1h,aux
 0200: e1 9d         jmp     x019d
 0201: cf 02 x0201:  xmit    HD_CMD,ivr
-0202: da 21         xmit    1h,driv[5]
+0202: da 21         xmit    1h,driv[5]		; trigger DMA Request
 0203: da 20         xmit    0h,driv[5]
 0204: e1 ff         jmp     x01ff
 0205: c0 51 x0205:  xmit    51h,aux
@@ -905,10 +921,10 @@ FDC_DATA     EQU  5fh
 020b: bc 2b x020b:  nzt     sriv[3],x020b
 020c: c4 00 x020c:  xmit    0h,r4
 020d: cf 5a         xmit    CSR1,ivr
-020e: d8 21         xmit    1h,driv[7]
+020e: d8 21         xmit    1h,driv[7]		; disable write gate
 020f: cf 02         xmit    HD_CMD,ivr
 0210: dd 20         xmit    0h,driv[2]
-0211: c9 1f         xmit    1fh,r11			; r11 = 0x1f = 31
+0211: c9 1f         xmit    1fh,r11		; r11 = 0x1f = 31
 0212: e7 37         jmp     x0737
 0213: c0 33 x0213:  xmit    33h,aux
 0214: 25 0f         add     r5,ivr
@@ -917,14 +933,14 @@ FDC_DATA     EQU  5fh
 0217: cf 3e         xmit    M_STATUS,ivr
 0218: da 21         xmit    1h,driv[5]
 0219: cf 02         xmit    HD_CMD,ivr
-021a: d9 21         xmit    1h,driv[6]
+021a: d9 21         xmit    1h,driv[6]		; trigger INT6
 021b: 04 00         move    r4,aux
 021c: 25 00         add     r5,aux
-021d: c9 20         xmit    20h,r11			; r11 = 0x20 = 32
+021d: c9 20         xmit    20h,r11		; r11 = 0x20 = 32
 021e: e7 2f         jmp     x072f
 021f: cf 3e x021f:  xmit    M_STATUS,ivr
 0220: db 20         xmit    0h,driv[4]
-0221: c9 21         xmit    21h,r11			; r11 = 0x21 = 33
+0221: c9 21         xmit    21h,r11		; r11 = 0x21 = 33
 0222: e7 3f         jmp     x073f
 0223: e0 18 x0223:  jmp     x0018
 
@@ -933,24 +949,24 @@ FDC_DATA     EQU  5fh
 0226: c9 f0 x0226:  xmit    0f0h,r11
 0227: cf 5d x0227:  xmit    CSR4,ivr
 0228: b9 2a         nzt     sriv[6],x022a
-0229: e2 27         jmp     x0227
+0229: e2 27         jmp     x0227		; waiting for INDEX
 022a: cf 5d x022a:  xmit    CSR4,ivr
-022b: b9 2a         nzt     sriv[6],x022a
+022b: b9 2a         nzt     sriv[6],x022a	; waiting for INDEX to clear
 022c: cf 5a         xmit    CSR1,ivr
 022d: db 66         xmit    6h,driv[6:4]
 022e: c6 b0         xmit    0b0h,r6
 022f: cf 5f x022f:  xmit    FDC_DATA,ivr
 0230: c0 4e         xmit    4eh,aux
-0231: 00 1f         move    aux,driv
+0231: 00 1f         move    aux,driv		; FDC_DATA = 0x4e
 0232: cf 5a x0232:  xmit    CSR1,ivr
-0233: be 32         nzt     sriv[1],x0232
+0233: be 32         nzt     sriv[1],x0232	; waiting for byte transfer flag
 0234: c0 01         xmit    1h,aux
 0235: 26 06         add     r6,r6
 0236: a6 2f         nzt     r6,x022f
 0237: c6 f4         xmit    0f4h,r6
 0238: c0 00 x0238:  xmit    0h,aux
 0239: cf 5f         xmit    FDC_DATA,ivr
-023a: 00 1f         move    aux,driv
+023a: 00 1f         move    aux,driv		; FDC_DATA = 0
 023b: c0 01         xmit    1h,aux
 023c: 26 06         add     r6,r6
 023d: a6 38         nzt     r6,x0238
@@ -959,14 +975,14 @@ FDC_DATA     EQU  5fh
 0240: c6 fd         xmit    0fdh,r6
 0241: cf 5f x0241:  xmit    FDC_DATA,ivr
 0242: c0 52         xmit    52h,aux
-0243: 00 1f         move    aux,driv
+0243: 00 1f         move    aux,driv		; FDC_DATA = 0x52
 0244: cf 5a x0244:  xmit    CSR1,ivr
-0245: be 24         nzt     sriv[1],x0244
+0245: be 24         nzt     sriv[1],x0244	; waiting for byte transfer flag
 0246: cf 5f         xmit    FDC_DATA,ivr
 0247: c0 24         xmit    24h,aux
-0248: 00 1f         move    aux,driv
+0248: 00 1f         move    aux,driv		; FDC_DATA = 0x24
 0249: cf 5a x0249:  xmit    CSR1,ivr
-024a: be 29         nzt     sriv[1],x0249
+024a: be 29         nzt     sriv[1],x0249	; waiting for byte transfer flag
 024b: c0 01         xmit    1h,aux
 024c: 26 06         add     r6,r6
 024d: a6 41         nzt     r6,x0241
@@ -974,26 +990,26 @@ FDC_DATA     EQU  5fh
 024f: db 66         xmit    6h,driv[6:4]
 0250: c0 fc         xmit    0fch,aux
 0251: cf 5f         xmit    FDC_DATA,ivr
-0252: 00 1f         move    aux,driv
+0252: 00 1f         move    aux,driv		; FDC_DATA = 0xfc
 0253: cf 5a x0253:  xmit    CSR1,ivr
-0254: be 33         nzt     sriv[1],x0253
+0254: be 33         nzt     sriv[1],x0253	; waiting for byte transfer flag
 0255: c6 d0 x0255:  xmit    0d0h,r6
 0256: c0 4e x0256:  xmit    4eh,aux
 0257: cf 5f         xmit    FDC_DATA,ivr
-0258: 00 1f         move    aux,driv
+0258: 00 1f         move    aux,driv		; FDC_DATA = 0x4e
 0259: cf 5a x0259:  xmit    CSR1,ivr
-025a: be 39         nzt     sriv[1],x0259
+025a: be 39         nzt     sriv[1],x0259	; waiting for byte transfer flag
 025b: c0 01         xmit    1h,aux
 025c: 26 06         add     r6,r6
 025d: a6 56         nzt     r6,x0256
 025e: c6 f4 x025e:  xmit    0f4h,r6
 025f: c0 00 x025f:  xmit    0h,aux
 0260: cf 5f         xmit    FDC_DATA,ivr
-0261: 00 1f         move    aux,driv
+0261: 00 1f         move    aux,driv		; FDC_DATA = 0
 0262: cf 5f         xmit    FDC_DATA,ivr
 0263: cf 5f         xmit    FDC_DATA,ivr
 0264: cf 5a x0264:  xmit    CSR1,ivr
-0265: be 24         nzt     sriv[1],x0264
+0265: be 24         nzt     sriv[1],x0264	; waiting for byte transfer flag
 0266: c0 01         xmit    1h,aux
 0267: 26 06         add     r6,r6
 0268: a6 5f         nzt     r6,x025f
@@ -1002,18 +1018,18 @@ FDC_DATA     EQU  5fh
 026b: c6 fd         xmit    0fdh,r6
 026c: cf 5f x026c:  xmit    FDC_DATA,ivr
 026d: c0 44         xmit    44h,aux
-026e: 00 1f         move    aux,driv
+026e: 00 1f         move    aux,driv		; FDC_DATA = 0x44
 026f: cf 5f         xmit    FDC_DATA,ivr
 0270: cf 5f         xmit    FDC_DATA,ivr
 0271: cf 5a x0271:  xmit    CSR1,ivr
-0272: be 31         nzt     sriv[1],x0271
+0272: be 31         nzt     sriv[1],x0271	; waiting for byte transfer flag
 0273: c0 89         xmit    89h,aux
 0274: cf 5f         xmit    FDC_DATA,ivr
-0275: 00 1f         move    aux,driv
+0275: 00 1f         move    aux,driv		; FDC_DATA = 0x89
 0276: cf 5f         xmit    FDC_DATA,ivr
 0277: cf 5f         xmit    FDC_DATA,ivr
 0278: cf 5a x0278:  xmit    CSR1,ivr
-0279: be 38         nzt     sriv[1],x0278
+0279: be 38         nzt     sriv[1],x0278	; waiting for byte transfer flag
 027a: c0 01         xmit    1h,aux
 027b: 26 06         add     r6,r6
 027c: a6 6c         nzt     r6,x026c
@@ -1021,34 +1037,34 @@ FDC_DATA     EQU  5fh
 027e: db 67         xmit    7h,driv[6:4]
 027f: cf 5f         xmit    FDC_DATA,ivr
 0280: c0 fe         xmit    0feh,aux
-0281: 00 1f         move    aux,driv
+0281: 00 1f         move    aux,driv		; FDC_DATA = 0xfe
 0282: cf 5f         xmit    FDC_DATA,ivr
 0283: cf 5f         xmit    FDC_DATA,ivr
 0284: cf 5a x0284:  xmit    CSR1,ivr
-0285: be 24         nzt     sriv[1],x0284
+0285: be 24         nzt     sriv[1],x0284	; waiting for byte transfer flag
 0286: cf 5f         xmit    FDC_DATA,ivr
-0287: 02 1f         move    r2,driv
+0287: 02 1f         move    r2,driv		; FDC_DATA = r2 (track number?)
 0288: cf 5f         xmit    FDC_DATA,ivr
 0289: cf 5f         xmit    FDC_DATA,ivr
 028a: cf 5a x028a:  xmit    CSR1,ivr
-028b: be 2a         nzt     sriv[1],x028a
+028b: be 2a         nzt     sriv[1],x028a	; waiting for byte transfer flag
 028c: cf 4b         xmit    VAL_3,ivr
 028d: 1b 20         move    sriv[4],aux
 028e: cf 5f         xmit    FDC_DATA,ivr
-028f: 00 1f         move    aux,driv
+028f: 00 1f         move    aux,driv		; FDC_DATA = VAL_3 sriv[4] (side select?)
 0290: cf 5f         xmit    FDC_DATA,ivr
 0291: cf 5f         xmit    FDC_DATA,ivr
 0292: cf 5a x0292:  xmit    CSR1,ivr
-0293: be 32         nzt     sriv[1],x0292
+0293: be 32         nzt     sriv[1],x0292	; waiting for byte transfer flag
 0294: cf 5f         xmit    FDC_DATA,ivr
-0295: 03 1f         move    r3,driv
+0295: 03 1f         move    r3,driv		; FDC_DATA = r3
 0296: cf 5f         xmit    FDC_DATA,ivr
 0297: cf 5f         xmit    FDC_DATA,ivr
 0298: cf 5a x0298:  xmit    CSR1,ivr
-0299: be 38         nzt     sriv[1],x0298
+0299: be 38         nzt     sriv[1],x0298	; waiting for byte transfer flag
 029a: c0 01         xmit    1h,aux
 029b: cf 5f         xmit    FDC_DATA,ivr
-029c: 00 1f         move    aux,driv
+029c: 00 1f         move    aux,driv		; FDC_DATA = 1
 029d: e2 a0         jmp     x02a0
 
 029e: 00 00         nop     
@@ -1057,14 +1073,14 @@ FDC_DATA     EQU  5fh
 02a0: cf 5f x02a0:  xmit    FDC_DATA,ivr
 02a1: cf 5f         xmit    FDC_DATA,ivr
 02a2: cf 5a x02a2:  xmit    CSR1,ivr
-02a3: be 22         nzt     sriv[1],x02a2
+02a3: be 22         nzt     sriv[1],x02a2	; waiting for byte transfer flag
 02a4: cf 5a         xmit    CSR1,ivr
 02a5: db 63         xmit    3h,driv[6:4]
 02a6: c6 fa         xmit    0fah,r6
 02a7: cf 5f x02a7:  xmit    FDC_DATA,ivr
 02a8: cf 5f         xmit    FDC_DATA,ivr
 02a9: cf 5a x02a9:  xmit    CSR1,ivr
-02aa: be 29         nzt     sriv[1],x02a9
+02aa: be 29         nzt     sriv[1],x02a9	; waiting for byte transfer flag
 02ab: cf 5f         xmit    FDC_DATA,ivr
 02ac: c0 01         xmit    1h,aux
 02ad: 26 06         add     r6,r6
@@ -1074,22 +1090,22 @@ FDC_DATA     EQU  5fh
 02b1: c6 ea         xmit    0eah,r6
 02b2: c0 4e x02b2:  xmit    4eh,aux
 02b3: cf 5f         xmit    FDC_DATA,ivr
-02b4: 00 1f         move    aux,driv
+02b4: 00 1f         move    aux,driv		; FDC_DATA = 0x4e
 02b5: c0 01         xmit    1h,aux
 02b6: cf 5f         xmit    FDC_DATA,ivr
 02b7: cf 5f         xmit    FDC_DATA,ivr
 02b8: cf 5a x02b8:  xmit    CSR1,ivr
-02b9: be 38         nzt     sriv[1],x02b8
+02b9: be 38         nzt     sriv[1],x02b8	; waiting for byte transfer flag
 02ba: 26 06         add     r6,r6
 02bb: a6 b2         nzt     r6,x02b2
 02bc: c6 f4         xmit    0f4h,r6
 02bd: c0 00 x02bd:  xmit    0h,aux
 02be: cf 5f         xmit    FDC_DATA,ivr
-02bf: 00 1f         move    aux,driv
+02bf: 00 1f         move    aux,driv		; FDC_DATA = 0
 02c0: cf 5f         xmit    FDC_DATA,ivr
 02c1: cf 5f         xmit    FDC_DATA,ivr
 02c2: cf 5a x02c2:  xmit    CSR1,ivr
-02c3: be 22         nzt     sriv[1],x02c2
+02c3: be 22         nzt     sriv[1],x02c2	; waiting for byte transfer flag
 02c4: c0 01         xmit    1h,aux
 02c5: 26 06         add     r6,r6
 02c6: a6 bd         nzt     r6,x02bd
@@ -1098,18 +1114,18 @@ FDC_DATA     EQU  5fh
 02c9: c6 fd         xmit    0fdh,r6
 02ca: cf 5f x02ca:  xmit    FDC_DATA,ivr
 02cb: c0 44         xmit    44h,aux
-02cc: 00 1f         move    aux,driv
+02cc: 00 1f         move    aux,driv		; FDC_DATA = 0x44
 02cd: cf 5f         xmit    FDC_DATA,ivr
 02ce: cf 5f         xmit    FDC_DATA,ivr
 02cf: cf 5a x02cf:  xmit    CSR1,ivr
-02d0: be 2f         nzt     sriv[1],x02cf
+02d0: be 2f         nzt     sriv[1],x02cf	; waiting for byte transfer flag
 02d1: c0 89         xmit    89h,aux
 02d2: cf 5f         xmit    FDC_DATA,ivr
-02d3: 00 1f         move    aux,driv
+02d3: 00 1f         move    aux,driv		; FDC_DATA = 0x89
 02d4: cf 5f         xmit    FDC_DATA,ivr
 02d5: cf 5f         xmit    FDC_DATA,ivr
 02d6: cf 5a x02d6:  xmit    CSR1,ivr
-02d7: be 36         nzt     sriv[1],x02d6
+02d7: be 36         nzt     sriv[1],x02d6	; waiting for byte transfer flag
 02d8: c0 01         xmit    1h,aux
 02d9: 26 06         add     r6,r6
 02da: a6 ca         nzt     r6,x02ca
@@ -1117,18 +1133,18 @@ FDC_DATA     EQU  5fh
 02dc: db 67         xmit    7h,driv[6:4]
 02dd: c0 fb         xmit    0fbh,aux
 02de: cf 5f         xmit    FDC_DATA,ivr
-02df: 00 1f         move    aux,driv
+02df: 00 1f         move    aux,driv		; FDC_DATA = 0xfb
 02e0: cf 5f         xmit    FDC_DATA,ivr
 02e1: cf 5f         xmit    FDC_DATA,ivr
 02e2: cf 5a x02e2:  xmit    CSR1,ivr
-02e3: be 22         nzt     sriv[1],x02e2
+02e3: be 22         nzt     sriv[1],x02e2	; waiting for byte transfer flag
 02e4: c6 00         xmit    0h,r6
 02e5: cf 5f x02e5:  xmit    FDC_DATA,ivr
-02e6: 04 1f         move    r4,driv
+02e6: 04 1f         move    r4,driv		; FDC_DATA = r4
 02e7: cf 5f         xmit    FDC_DATA,ivr
 02e8: cf 5f         xmit    FDC_DATA,ivr
 02e9: cf 5a x02e9:  xmit    CSR1,ivr
-02ea: be 29         nzt     sriv[1],x02e9
+02ea: be 29         nzt     sriv[1],x02e9	; waiting for byte transfer flag
 02eb: c0 01         xmit    1h,aux
 02ec: 26 06         add     r6,r6
 02ed: a6 e5         nzt     r6,x02e5
@@ -1138,7 +1154,7 @@ FDC_DATA     EQU  5fh
 02f1: cf 5f x02f1:  xmit    FDC_DATA,ivr
 02f2: cf 5f         xmit    FDC_DATA,ivr
 02f3: cf 5a x02f3:  xmit    CSR1,ivr
-02f4: be 33         nzt     sriv[1],x02f3
+02f4: be 33         nzt     sriv[1],x02f3	; waiting for byte transfer flag
 02f5: cf 5f         xmit    FDC_DATA,ivr
 02f6: c0 01         xmit    1h,aux
 02f7: 26 06         add     r6,r6
@@ -1146,7 +1162,7 @@ FDC_DATA     EQU  5fh
 02f9: cf 5f         xmit    FDC_DATA,ivr
 02fa: cf 5f         xmit    FDC_DATA,ivr
 02fb: cf 5a x02fb:  xmit    CSR1,ivr
-02fc: be 3b         nzt     sriv[1],x02fb
+02fc: be 3b         nzt     sriv[1],x02fb	; waiting for byte transfer flag
 02fd: cf 5a         xmit    CSR1,ivr
 02fe: db 66         xmit    6h,driv[6:4]
 02ff: c0 01         xmit    1h,aux
@@ -1154,12 +1170,12 @@ FDC_DATA     EQU  5fh
 0301: a9 03         nzt     r11,x0303
 0302: e3 0c         jmp     x030c
 0303: cf 3f x0303:  xmit    DMA,ivr
-0304: 1f 03         move    sriv,r3
+0304: 1f 03         move    sriv,r3		; get byte from DMA
 0305: 29 00         add     r11,aux
 0306: a0 08         nzt     aux,x0308
 0307: e2 5e         jmp     x025e
 0308: cf 02 x0308:  xmit    HD_CMD,ivr
-0309: da 21         xmit    1h,driv[5]
+0309: da 21         xmit    1h,driv[5]		; trigger DMA Request
 030a: da 20         xmit    0h,driv[5]
 030b: e2 55         jmp     x0255
 030c: cf 5f x030c:  xmit    FDC_DATA,ivr
@@ -1168,9 +1184,9 @@ FDC_DATA     EQU  5fh
 030f: cf 5f         xmit    FDC_DATA,ivr
 0310: cf 5f         xmit    FDC_DATA,ivr
 0311: cf 5a x0311:  xmit    CSR1,ivr
-0312: be 31         nzt     sriv[1],x0311
+0312: be 31         nzt     sriv[1],x0311	; waiting for byte transfer flag
 0313: cf 5d x0313:  xmit    CSR4,ivr
-0314: b9 33         nzt     sriv[6],x0313
+0314: b9 33         nzt     sriv[6],x0313	; waiting for INDEX to clear
 0315: e2 0c         jmp     x020c
 
 ; ---------------------------
@@ -1178,29 +1194,29 @@ FDC_DATA     EQU  5fh
 
 0316: c1 4b x0316:  xmit    4bh,r1
 0317: c2 fc         xmit    0fch,r2
-0318: c9 22         xmit    22h,r11			; r11 = 0x22 = 34
+0318: c9 22         xmit    22h,r11		; r11 = 0x22 = 34
 0319: e6 6c         jmp     x066c
 
 031a: a0 1c x031a:  nzt     aux,x031c
 031b: e3 1d         jmp     x031d
 031c: e0 9e x031c:  jmp     x009e
 031d: cf 02 x031d:  xmit    HD_CMD,ivr
-031e: d9 20         xmit    0h,driv[6]
+031e: d9 20         xmit    0h,driv[6]		; clear INT6
 031f: cf 3e         xmit    M_STATUS,ivr
 0320: db 21         xmit    1h,driv[4]
 0321: da 20         xmit    0h,driv[5]
-0322: c9 23         xmit    23h,r11			; r11 = 0x23 = 35
-0323: e6 3d         jmp     x063d			; select drive
+0322: c9 23         xmit    23h,r11		; r11 = 0x23 = 35
+0323: e6 3d         jmp     x063d		; select drive
 
 0324: a0 26 x0324:  nzt     aux,x0326
 0325: e3 27         jmp     x0327
 0326: e2 24 x0326:  jmp     x0224
-0327: c9 24 x0327:  xmit    24h,r11			; r11 = 0x24 = 36
-0328: e7 4b         jmp     x074b			; get drive type
+0327: c9 24 x0327:  xmit    24h,r11		; r11 = 0x24 = 36
+0328: e7 4b         jmp     x074b		; get drive type
 
 0329: cf 3c x0329:  xmit    IOc,ivr
 032a: 80 2e         xec     x032e,aux
-032b: c9 25         xmit    25h,r11			; r11 = 0x25 = 37
+032b: c9 25         xmit    25h,r11		; r11 = 0x25 = 37
 032c: e6 94         jmp     x0694
 
 032d: e3 33 x032d:  jmp     x0333
@@ -1215,8 +1231,8 @@ FDC_DATA     EQU  5fh
 0333: cf 4b x0333:  xmit    VAL_3,ivr
 0334: 1b 60         move    sriv[6:4],aux
 0335: cf 5c x0335:  xmit    CSR3,ivr
-0336: 00 7e         move    aux,driv[3:1]
-0337: c9 26         xmit    26h,r11			; r11 = 0x26 = 38
+0336: 00 7e         move    aux,driv[3:1]	; head select = VAL_3[6:4]
+0337: c9 26         xmit    26h,r11		; r11 = 0x26 = 38
 0338: e7 68         jmp     x0768
 0339: 86 35 x0339:  xec     x0335,r6
 033a: e3 40         jmp     x0340
@@ -1228,13 +1244,18 @@ FDC_DATA     EQU  5fh
 033f: 00 00         nop     
 
 0340: 85 41 x0340:  xec     x0341,r5
-0341: e3 bf x0341:  jmp     x03bf
-0342: e3 65         jmp     x0365
+0341: e3 bf x0341:  jmp     x03bf		; FD
+0342: e3 65         jmp     x0365		; HD
+
+; called with aux containing offset for data tables
+; two tables of nine values
+; data sent to IO7, IO5 (FD) or IO8, IO6 (HD)
+
 0343: 00 01 x0343:  move    aux,r1
 0344: c0 37         xmit    37h,aux
 0345: 25 0f         add     r5,ivr
 0346: 81 46 x0346:  xec     x0346,r1
-0347: 02 1f         move    r2,driv
+0347: 02 1f         move    r2,driv		; r2 -> IO7 (FD) or IO8 (HD)
 0348: e3 52         jmp     x0352
 0349: c2 03         xmit    3h,r2
 034a: c2 02         xmit    2h,r2
@@ -1248,7 +1269,7 @@ FDC_DATA     EQU  5fh
 0352: c0 35 x0352:  xmit    35h,aux
 0353: 25 0f         add     r5,ivr
 0354: 81 54 x0354:  xec     x0354,r1
-0355: 02 1f         move    r2,driv
+0355: 02 1f         move    r2,driv		; r2 -> IO5 (FD) or IO6 (HD)
 0356: e3 60         jmp     x0360
 0357: c2 04         xmit    4h,r2
 0358: c2 04         xmit    4h,r2
@@ -1260,13 +1281,15 @@ FDC_DATA     EQU  5fh
 035e: c2 20         xmit    20h,r2
 035f: c2 02         xmit    2h,r2
 0360: cf 02 x0360:  xmit    HD_CMD,ivr
-0361: df 20         xmit    0h,driv[0]
+0361: df 20         xmit    0h,driv[0]		; clear RDGATE, resets zero detector
 0362: de 20         xmit    0h,driv[1]
 0363: c4 40         xmit    40h,r4
 0364: e2 13         jmp     x0213
-0365: c9 27 x0365:  xmit    27h,r11			; r11 = 0x27 = 39
+
+; HD
+0365: c9 27 x0365:  xmit    27h,r11		; r11 = 0x27 = 39
 0366: e4 d5         jmp     x04d5
-0367: c9 28 x0367:  xmit    28h,r11			; r11 = 0x28 = 40
+0367: c9 28 x0367:  xmit    28h,r11		; r11 = 0x28 = 40
 0368: e4 49         jmp     x0449
 0369: a0 6b x0369:  nzt     aux,x036b
 036a: e3 6c         jmp     x036c
@@ -1277,9 +1300,9 @@ FDC_DATA     EQU  5fh
 036f: dd 21         xmit    1h,driv[2]
 0370: cf 01         xmit    DATA_PORT,ivr
 0371: c2 a1         xmit    0a1h,r2
-0372: 02 1f         move    r2,driv
+0372: 02 1f         move    r2,driv		; DATA_PORT = 0xa1
 0373: cf 5a         xmit    CSR1,ivr
-0374: d8 20         xmit    0h,driv[7]
+0374: d8 20         xmit    0h,driv[7]		; enable write gate
 0375: c0 01         xmit    1h,aux
 0376: cf 03         xmit    HD_STATUS,ivr
 0377: bc 37 x0377:  nzt     sriv[3],x0377
@@ -1297,7 +1320,7 @@ FDC_DATA     EQU  5fh
 0383: bc 23 x0383:  nzt     sriv[3],x0383
 0384: cf 01         xmit    DATA_PORT,ivr
 0385: c2 f8         xmit    0f8h,r2
-0386: 02 1f         move    r2,driv
+0386: 02 1f         move    r2,driv		; DATA_PORT = 0xf8
 0387: cf 03         xmit    HD_STATUS,ivr
 0388: bc 28 x0388:  nzt     sriv[3],x0388
 0389: cf 01         xmit    DATA_PORT,ivr
@@ -1309,7 +1332,7 @@ FDC_DATA     EQU  5fh
 038f: 17 1f         move    sliv,driv
 0390: c7 ff         xmit    0ffh,ivl
 0391: cf 03         xmit    HD_STATUS,ivr
-0392: ba 2d         nzt     sriv[5],x038d
+0392: ba 2d         nzt     sriv[5],x038d	; not full?
 0393: bc 33 x0393:  nzt     sriv[3],x0393
 0394: cf 01         xmit    DATA_PORT,ivr
 0395: 17 1f         move    sliv,driv
@@ -1325,7 +1348,7 @@ FDC_DATA     EQU  5fh
 039f: bc 3f x039f:  nzt     sriv[3],x039f
 03a0: e7 98         jmp     x0798
 03a1: cf 5a x03a1:  xmit    CSR1,ivr
-03a2: d8 21         xmit    1h,driv[7]
+03a2: d8 21         xmit    1h,driv[7]		; disable write gate
 03a3: cf 02         xmit    HD_CMD,ivr
 03a4: dd 20         xmit    0h,driv[2]
 03a5: cf 4e x03a5:  xmit    VAL_6,ivr
@@ -1351,41 +1374,43 @@ FDC_DATA     EQU  5fh
 03b8: c0 01 x03b8:  xmit    1h,aux
 03b9: 3b 7b         add     sriv[6:4],driv[6:4]
 03ba: e3 33         jmp     x0333
-03bb: e6 36 x03bb:  jmp     x0636
+03bb: e6 36 x03bb:  jmp     x0636		; set head select
 03bc: c0 01 x03bc:  xmit    1h,aux
-03bd: 3f 1f         add     sriv,driv
+03bd: 3f 1f         add     sriv,driv		; VAL_4++ (track number++)
 03be: e3 1d         jmp     x031d
+
+; FD
 03bf: cf 5d x03bf:  xmit    CSR4,ivr
-03c0: ba 23         nzt     sriv[5],x03c3
+03c0: ba 23         nzt     sriv[5],x03c3	; check write protect
 03c1: c0 0b         xmit    0bh,aux
 03c2: e3 43         jmp     x0343
-03c3: c9 29 x03c3:  xmit    29h,r11			; r11 = 0x29 = 41
+03c3: c9 29 x03c3:  xmit    29h,r11		; r11 = 0x29 = 41
 03c4: e4 c4         jmp     x04c4
 03c5: cf 5b x03c5:  xmit    CSR2,ivr
 03c6: c0 40         xmit    40h,aux
-03c7: 00 1f         move    aux,driv
+03c7: 00 1f         move    aux,driv		; CSR2 = 0x40 (mode: disk write)
 03c8: c0 00         xmit    0h,aux
 03c9: cf 02         xmit    HD_CMD,ivr
-03ca: da 21         xmit    1h,driv[5]
+03ca: da 21         xmit    1h,driv[5]		; trigger DMA Request
 03cb: da 20         xmit    0h,driv[5]
 03cc: cf 03         xmit    HD_STATUS,ivr
-03cd: b9 2d x03cd:  nzt     sriv[6],x03cd
+03cd: b9 2d x03cd:  nzt     sriv[6],x03cd	; wait for DMA ACK
 03ce: c2 00 x03ce:  xmit    0h,r2
-03cf: c9 2a         xmit    2ah,r11			; r11 = 0x2a = 42
+03cf: c9 2a         xmit    2ah,r11		; r11 = 0x2a = 42
 03d0: e4 ee         jmp     x04ee
 03d1: a0 ce x03d1:  nzt     aux,x03ce
-03d2: c9 2b         xmit    2bh,r11			; r11 = 0x2b = 43
+03d2: c9 2b         xmit    2bh,r11		; r11 = 0x2b = 43
 03d3: e7 7b         jmp     x077b
 03d4: cf 4c x03d4:  xmit    VAL_4,ivr
-03d5: c0 d5         xmit    0d5h,aux
-03d6: 3f 00         add     sriv,aux
+03d5: c0 d5         xmit    0d5h,aux		; aux = 213
+03d6: 3f 00         add     sriv,aux		; aux += track number
 03d7: cf 5b         xmit    CSR2,ivr
-03d8: d8 21         xmit    1h,driv[7]
-03d9: a8 db         nzt     ovf,x03db
-03da: d8 20         xmit    0h,driv[7]
+03d8: d8 21         xmit    1h,driv[7]		; enable precomp
+03d9: a8 db         nzt     ovf,x03db		; track number >= 43?, leave precomp enabled
+03da: d8 20         xmit    0h,driv[7]		; disable precomp
 03db: cf 5a x03db:  xmit    CSR1,ivr
 03dc: db 66         xmit    6h,driv[6:4]
-03dd: d8 20         xmit    0h,driv[7]
+03dd: d8 20         xmit    0h,driv[7]		; enable write gate
 03de: c0 01         xmit    1h,aux
 03df: c1 f5         xmit    0f5h,r1
 03e0: cf 5f x03e0:  xmit    FDC_DATA,ivr
@@ -1393,7 +1418,7 @@ FDC_DATA     EQU  5fh
 03e2: cf 5f         xmit    FDC_DATA,ivr
 03e3: cf 5f         xmit    FDC_DATA,ivr
 03e4: cf 5a x03e4:  xmit    CSR1,ivr
-03e5: be 24         nzt     sriv[1],x03e4
+03e5: be 24         nzt     sriv[1],x03e4	; waiting for byte transfer flag
 03e6: 21 01         add     r1,r1
 03e7: a1 e0         nzt     r1,x03e0
 03e8: cf 5a         xmit    CSR1,ivr
@@ -1406,7 +1431,7 @@ FDC_DATA     EQU  5fh
 03ef: cf 5f         xmit    FDC_DATA,ivr
 03f0: cf 5f         xmit    FDC_DATA,ivr
 03f1: cf 5a x03f1:  xmit    CSR1,ivr
-03f2: be 31         nzt     sriv[1],x03f1
+03f2: be 31         nzt     sriv[1],x03f1	; waiting for byte transfer flag
 03f3: cf 5f         xmit    FDC_DATA,ivr
 03f4: c0 89         xmit    89h,aux
 03f5: 00 1f         move    aux,driv
@@ -1414,7 +1439,7 @@ FDC_DATA     EQU  5fh
 03f7: cf 5f         xmit    FDC_DATA,ivr
 03f8: cf 5f         xmit    FDC_DATA,ivr
 03f9: cf 5a x03f9:  xmit    CSR1,ivr
-03fa: be 39         nzt     sriv[1],x03f9
+03fa: be 39         nzt     sriv[1],x03f9	; waiting for byte transfer flag
 03fb: 23 03         add     r3,r3
 03fc: a3 ec         nzt     r3,x03ec
 03fd: cf 5f         xmit    FDC_DATA,ivr
@@ -1422,33 +1447,33 @@ FDC_DATA     EQU  5fh
 03ff: 03 1f         move    r3,driv
 0400: c1 00         xmit    0h,r1
 0401: c0 01         xmit    1h,aux
-0402: cf 5a x0402:  xmit    CSR1,ivr
+0402: cf 5a x0402:  xmit    CSR1,ivr		; byte transfer loop
 0403: db 67         xmit    7h,driv[6:4]
 0404: cf 5f         xmit    FDC_DATA,ivr
 0405: cf 5f         xmit    FDC_DATA,ivr
 0406: cf 5a x0406:  xmit    CSR1,ivr
-0407: be 26         nzt     sriv[1],x0406
+0407: be 26         nzt     sriv[1],x0406	; waiting for byte transfer flag
 0408: cf 03         xmit    HD_STATUS,ivr
-0409: b9 2b         nzt     sriv[6],x040b
+0409: b9 2b         nzt     sriv[6],x040b	; DMA ACK?
 040a: e4 47         jmp     x0447
 040b: cf 3f x040b:  xmit    DMA,ivr
-040c: 1f 03         move    sriv,r3
+040c: 1f 03         move    sriv,r3		; get byte from DMA
 040d: cf 5f         xmit    FDC_DATA,ivr
-040e: 03 1f         move    r3,driv
+040e: 03 1f         move    r3,driv		; send to floppy
 040f: 21 01         add     r1,r1
-0410: a1 12         nzt     r1,x0412
+0410: a1 12         nzt     r1,x0412		; sector (256 bytes) transferred?
 0411: e4 16         jmp     x0416
 0412: cf 02 x0412:  xmit    HD_CMD,ivr
-0413: da 21         xmit    1h,driv[5]
+0413: da 21         xmit    1h,driv[5]		; trigger DMA Request
 0414: da 20         xmit    0h,driv[5]
 0415: e4 02         jmp     x0402
-0416: c1 fc x0416:  xmit    0fch,r1
+0416: c1 fc x0416:  xmit    0fch,r1		; sector transfer done
 0417: cf 5f         xmit    FDC_DATA,ivr
 0418: cf 5f         xmit    FDC_DATA,ivr
 0419: cf 5a x0419:  xmit    CSR1,ivr
-041a: be 39         nzt     sriv[1],x0419
+041a: be 39         nzt     sriv[1],x0419	; waiting for byte transfer flag
 041b: cf 5a         xmit    CSR1,ivr
-041c: d9 20         xmit    0h,driv[6]
+041c: d9 20         xmit    0h,driv[6]		; CRC disable
 041d: e4 20 x041d:  jmp     x0420
 
 041e: 00 00         nop     
@@ -1457,7 +1482,7 @@ FDC_DATA     EQU  5fh
 0420: cf 5f x0420:  xmit    FDC_DATA,ivr
 0421: cf 5f         xmit    FDC_DATA,ivr
 0422: cf 5a x0422:  xmit    CSR1,ivr
-0423: be 22         nzt     sriv[1],x0422
+0423: be 22         nzt     sriv[1],x0422	; waiting for byte transfer flag
 0424: cf 5f         xmit    FDC_DATA,ivr
 0425: c0 01         xmit    1h,aux
 0426: 21 01         add     r1,r1
@@ -1468,16 +1493,16 @@ FDC_DATA     EQU  5fh
 042b: cf 5f         xmit    FDC_DATA,ivr
 042c: cf 5f         xmit    FDC_DATA,ivr
 042d: cf 5a x042d:  xmit    CSR1,ivr
-042e: be 2d         nzt     sriv[1],x042d
+042e: be 2d         nzt     sriv[1],x042d	; waiting for byte transfer flag
 042f: cf 5f         xmit    FDC_DATA,ivr
 0430: cf 5f         xmit    FDC_DATA,ivr
 0431: cf 5f         xmit    FDC_DATA,ivr
 0432: cf 5a x0432:  xmit    CSR1,ivr
-0433: be 32         nzt     sriv[1],x0432
+0433: be 32         nzt     sriv[1],x0432	; waiting for byte transfer flag
 0434: cf 5a         xmit    CSR1,ivr
-0435: d8 21         xmit    1h,driv[7]
+0435: d8 21         xmit    1h,driv[7]		; disable write gate
 0436: cf 5b x0436:  xmit    CSR2,ivr
-0437: d9 21         xmit    1h,driv[6]
+0437: d9 21         xmit    1h,driv[6]		; set mode: read locked onto crystal osc
 0438: cf 4e         xmit    VAL_6,ivr
 0439: c0 01         xmit    1h,aux
 043a: 3f 1f         add     sriv,driv
@@ -1495,20 +1520,23 @@ FDC_DATA     EQU  5fh
 0446: e3 39 x0446:  jmp     x0339
 0447: c0 0a x0447:  xmit    0ah,aux
 0448: e3 43         jmp     x0343
-0449: c1 a1 x0449:  xmit    0a1h,r1
-044a: c2 fe         xmit    0feh,r2
+
+; bunch of reg setup
+
+0449: c1 a1 x0449:  xmit    0a1h,r1		; r1 = 0xa1
+044a: c2 fe         xmit    0feh,r2		; r2 = 0xfe
 044b: cf 4b         xmit    VAL_3,ivr
-044c: 1f 03         move    sriv,r3
+044c: 1f 03         move    sriv,r3		; r3 = VAL_3
 044d: cf 4c         xmit    VAL_4,ivr
-044e: 1f 04         move    sriv,r4
+044e: 1f 04         move    sriv,r4		; r4 = track number
 044f: cf 50         xmit    VAL_8,ivr
-0450: df 10         xmit    10h,driv
+0450: df 10         xmit    10h,driv		; VAL_8 = 0x10
 0451: cf 51         xmit    VAL_9,ivr
-0452: 05 1f         move    r5,driv
+0452: 05 1f         move    r5,driv		; VAL_9 = r5
 0453: cf 52         xmit    VAL_a,ivr
-0454: 06 1f         move    r6,driv
+0454: 06 1f         move    r6,driv		; VAL_a = r6
 0455: cf 4d         xmit    VAL_5,ivr
-0456: 1f 05         move    sriv,r5
+0456: 1f 05         move    sriv,r5		; r5 = VAL_5
 0457: c0 01 x0457:  xmit    1h,aux
 0458: e4 60         jmp     x0460
 
@@ -1521,7 +1549,7 @@ FDC_DATA     EQU  5fh
 045f: 00 00         nop     
 
 0460: cf 02 x0460:  xmit    HD_CMD,ivr
-0461: c6 94         xmit    94h,r6
+0461: c6 94         xmit    94h,r6		; HD_CMD = 0x94
 0462: 06 1f         move    r6,driv
 0463: c6 fa         xmit    0fah,r6
 0464: c0 01         xmit    1h,aux
@@ -1532,8 +1560,7 @@ FDC_DATA     EQU  5fh
 0469: 00 00         nop     
 046a: dd 20         xmit    0h,driv[2]
 046b: cf 03         xmit    HD_STATUS,ivr
-
-046c: be 2e x046c:  nzt     sriv[1],x046e
+046c: be 2e x046c:  nzt     sriv[1],x046e	; wait for 16Z
 046d: e4 6c         jmp     x046c
 046e: c6 f8 x046e:  xmit    0f8h,r6
 046f: c0 01 x046f:  xmit    1h,aux
@@ -1555,36 +1582,36 @@ FDC_DATA     EQU  5fh
 047f: cf 03         xmit    HD_STATUS,ivr
 0480: bc 20 x0480:  nzt     sriv[3],x0480
 0481: cf 01         xmit    DATA_PORT,ivr
-0482: 7f 00         xor     sriv,aux
+0482: 7f 00         xor     sriv,aux		; aux = DATA_PORT ^ r2
 0483: cf 03         xmit    HD_STATUS,ivr
 0484: a0 c3         nzt     aux,x04c3
 0485: 03 00         move    r3,aux
 0486: bc 26 x0486:  nzt     sriv[3],x0486
 0487: cf 01         xmit    DATA_PORT,ivr
-0488: 7f 00         xor     sriv,aux
+0488: 7f 00         xor     sriv,aux		; aux = DATA_PORT ^ r3
 0489: cf 03         xmit    HD_STATUS,ivr
 048a: a0 b0         nzt     aux,x04b0
 048b: 04 00         move    r4,aux
 048c: bc 2c x048c:  nzt     sriv[3],x048c
 048d: cf 01         xmit    DATA_PORT,ivr
-048e: 7f 00         xor     sriv,aux
+048e: 7f 00         xor     sriv,aux		; aux = DATA_PORT ^ r4
 048f: cf 03         xmit    HD_STATUS,ivr
 0490: a0 b2         nzt     aux,x04b2
 0491: 04 00         move    r4,aux
 0492: bc 32 x0492:  nzt     sriv[3],x0492
 0493: cf 01         xmit    DATA_PORT,ivr
-0494: 1f 01         move    sriv,r1
+0494: 1f 01         move    sriv,r1		; r1 = DATA_PORT
 0495: cf 03         xmit    HD_STATUS,ivr
 0496: bc 36 x0496:  nzt     sriv[3],x0496
 0497: e7 88         jmp     x0788
 0498: cf 01 x0498:  xmit    DATA_PORT,ivr
-0499: bf 1b         nzt     sriv,x049b
+0499: bf 1b         nzt     sriv,x049b		; DATA_PORT != 0?
 049a: e4 9c         jmp     x049c
 049b: e4 b4 x049b:  jmp     x04b4
 049c: cf 03 x049c:  xmit    HD_STATUS,ivr
 049d: bc 3d x049d:  nzt     sriv[3],x049d
 049e: cf 01         xmit    DATA_PORT,ivr
-049f: bf 1b         nzt     sriv,x049b
+049f: bf 1b         nzt     sriv,x049b		; DATA_PORT != 0?
 04a0: e4 a2         jmp     x04a2
 04a1: e4 b4         jmp     x04b4
 04a2: 01 00 x04a2:  move    r1,aux
@@ -1592,7 +1619,7 @@ FDC_DATA     EQU  5fh
 04a4: a0 ae         nzt     aux,x04ae
 04a5: c0 00         xmit    0h,aux
 04a6: cf 02 x04a6:  xmit    HD_CMD,ivr
-04a7: df 20         xmit    0h,driv[0]
+04a7: df 20         xmit    0h,driv[0]		; clear RDGATE, resets zero detector
 04a8: de 20         xmit    0h,driv[1]
 04a9: cf 51         xmit    VAL_9,ivr
 04aa: 1f 05         move    sriv,r5
@@ -1648,11 +1675,11 @@ FDC_DATA     EQU  5fh
 04da: cf 3f x04da:  xmit    DMA,ivr
 04db: 86 e3         xec     x04e3,r6
 04dc: cf 02         xmit    HD_CMD,ivr
-04dd: da 21         xmit    1h,driv[5]
+04dd: da 21         xmit    1h,driv[5]		; trigger DMA Request
 04de: da 20         xmit    0h,driv[5]
 04df: cf 03         xmit    HD_STATUS,ivr
-04e0: b9 20 x04e0:  nzt     sriv[6],x04e0
-04e1: b9 23 x04e1:  nzt     sriv[6],x04e3
+04e0: b9 20 x04e0:  nzt     sriv[6],x04e0	; wait for DMA ACK
+04e1: b9 23 x04e1:  nzt     sriv[6],x04e3	; wait for DMA ACK cleared
 04e2: e4 e1         jmp     x04e1
 04e3: cf 3f x04e3:  xmit    DMA,ivr
 04e4: 86 e5         xec     x04e5,r6
@@ -1670,12 +1697,12 @@ FDC_DATA     EQU  5fh
 04f0: 00 1f         move    aux,driv
 04f1: cf 5b x04f1:  xmit    CSR2,ivr
 04f2: c1 40         xmit    40h,r1
-04f3: 01 1f         move    r1,driv
+04f3: 01 1f         move    r1,driv		; CSR2 = 0x40
 04f4: c0 01         xmit    1h,aux
 04f5: 21 01 x04f5:  add     r1,r1
 04f6: a1 f5         nzt     r1,x04f5
 04f7: cf 5b         xmit    CSR2,ivr
-04f8: d9 20         xmit    0h,driv[6]
+04f8: d9 20         xmit    0h,driv[6]		; set mode: disk read
 04f9: c1 fd x04f9:  xmit    0fdh,r1
 04fa: e7 6d         jmp     x076d
 04fb: cf 5a x04fb:  xmit    CSR1,ivr
@@ -1688,7 +1715,7 @@ FDC_DATA     EQU  5fh
 0500: cf 5f x0500:  xmit    FDC_DATA,ivr
 0501: cf 5f         xmit    FDC_DATA,ivr
 0502: cf 5a x0502:  xmit    CSR1,ivr
-0503: be 22         nzt     sriv[1],x0502
+0503: be 22         nzt     sriv[1],x0502	; waiting for byte transfer flag
 0504: cf 5f         xmit    FDC_DATA,ivr
 0505: bf 07         nzt     sriv,x0507
 0506: e5 08         jmp     x0508
@@ -1702,7 +1729,7 @@ FDC_DATA     EQU  5fh
 050e: cf 5f         xmit    FDC_DATA,ivr
 050f: cf 5f         xmit    FDC_DATA,ivr
 0510: cf 5a x0510:  xmit    CSR1,ivr
-0511: be 30         nzt     sriv[1],x0510
+0511: be 30         nzt     sriv[1],x0510	; waiting for byte transfer flag
 0512: cf 5a         xmit    CSR1,ivr
 0513: db 67         xmit    7h,driv[6:4]
 0514: c0 44         xmit    44h,aux
@@ -1714,7 +1741,7 @@ FDC_DATA     EQU  5fh
 051a: cf 5f x051a:  xmit    FDC_DATA,ivr
 051b: cf 5f         xmit    FDC_DATA,ivr
 051c: cf 5a x051c:  xmit    CSR1,ivr
-051d: be 3c         nzt     sriv[1],x051c
+051d: be 3c         nzt     sriv[1],x051c	; waiting for byte transfer flag
 051e: c0 89         xmit    89h,aux
 051f: cf 5f         xmit    FDC_DATA,ivr
 0520: 7f 00         xor     sriv,aux
@@ -1722,7 +1749,7 @@ FDC_DATA     EQU  5fh
 0522: cf 5f         xmit    FDC_DATA,ivr
 0523: cf 5f         xmit    FDC_DATA,ivr
 0524: cf 5a x0524:  xmit    CSR1,ivr
-0525: be 24         nzt     sriv[1],x0524
+0525: be 24         nzt     sriv[1],x0524	; waiting for byte transfer flag
 0526: c0 a1         xmit    0a1h,aux
 0527: cf 5f         xmit    FDC_DATA,ivr
 0528: 7f 01         xor     sriv,r1
@@ -1732,7 +1759,7 @@ FDC_DATA     EQU  5fh
 052c: cf 5f x052c:  xmit    FDC_DATA,ivr
 052d: cf 5f         xmit    FDC_DATA,ivr
 052e: cf 5a x052e:  xmit    CSR1,ivr
-052f: be 2e         nzt     sriv[1],x052e
+052f: be 2e         nzt     sriv[1],x052e	; waiting for byte transfer flag
 0530: cf 5f         xmit    FDC_DATA,ivr
 0531: 7f 01         xor     sriv,r1
 0532: a1 34         nzt     r1,x0534
@@ -1741,7 +1768,7 @@ FDC_DATA     EQU  5fh
 0535: cf 5f x0535:  xmit    FDC_DATA,ivr
 0536: cf 5f         xmit    FDC_DATA,ivr
 0537: cf 5a x0537:  xmit    CSR1,ivr
-0538: be 37         nzt     sriv[1],x0537
+0538: be 37         nzt     sriv[1],x0537	; waiting for byte transfer flag
 0539: 82 3b         xec     x053b,r2
 053a: e5 3d         jmp     x053d
 053b: c0 fe x053b:  xmit    0feh,aux
@@ -1761,19 +1788,19 @@ FDC_DATA     EQU  5fh
 0549: cf 5f x0549:  xmit    FDC_DATA,ivr
 054a: cf 5f         xmit    FDC_DATA,ivr
 054b: cf 5a x054b:  xmit    CSR1,ivr
-054c: be 2b         nzt     sriv[1],x054b
+054c: be 2b         nzt     sriv[1],x054b	; waiting for byte transfer flag
 054d: cf 4c         xmit    VAL_4,ivr
-054e: 1f 00         move    sriv,aux
+054e: 1f 00         move    sriv,aux		; aux = track number
 054f: cf 5f         xmit    FDC_DATA,ivr
-0550: 7f 00         xor     sriv,aux
-0551: a0 53         nzt     aux,x0553
+0550: 7f 00         xor     sriv,aux		; aux = FDC_DATA ^ track number
+0551: a0 53         nzt     aux,x0553		; FDC_DATA and track number differ
 0552: e5 55         jmp     x0555
 0553: c0 06 x0553:  xmit    6h,aux
 0554: e3 43         jmp     x0343
 0555: cf 5f x0555:  xmit    FDC_DATA,ivr
 0556: cf 5f         xmit    FDC_DATA,ivr
 0557: cf 5a x0557:  xmit    CSR1,ivr
-0558: be 37         nzt     sriv[1],x0557
+0558: be 37         nzt     sriv[1],x0557	; waiting for byte transfer flag
 0559: cf 4b         xmit    VAL_3,ivr
 055a: 1b 60         move    sriv[6:4],aux
 055b: cf 5f         xmit    FDC_DATA,ivr
@@ -1785,7 +1812,7 @@ FDC_DATA     EQU  5fh
 0561: cf 5f x0561:  xmit    FDC_DATA,ivr
 0562: cf 5f         xmit    FDC_DATA,ivr
 0563: cf 5a x0563:  xmit    CSR1,ivr
-0564: be 23         nzt     sriv[1],x0563
+0564: be 23         nzt     sriv[1],x0563	; waiting for byte transfer flag
 0565: cf 4d         xmit    VAL_5,ivr
 0566: 1f 00         move    sriv,aux
 0567: cf 5f         xmit    FDC_DATA,ivr
@@ -1796,7 +1823,7 @@ FDC_DATA     EQU  5fh
 056c: cf 5f x056c:  xmit    FDC_DATA,ivr
 056d: cf 5f         xmit    FDC_DATA,ivr
 056e: cf 5a x056e:  xmit    CSR1,ivr
-056f: be 2e         nzt     sriv[1],x056e
+056f: be 2e         nzt     sriv[1],x056e	; waiting for byte transfer flag
 0570: c0 01         xmit    1h,aux
 0571: cf 5f         xmit    FDC_DATA,ivr
 0572: 7f 00         xor     sriv,aux
@@ -1807,7 +1834,7 @@ FDC_DATA     EQU  5fh
 0577: cf 5f x0577:  xmit    FDC_DATA,ivr
 0578: cf 5f         xmit    FDC_DATA,ivr
 0579: cf 5a x0579:  xmit    CSR1,ivr
-057a: be 39         nzt     sriv[1],x0579
+057a: be 39         nzt     sriv[1],x0579	; waiting for byte transfer flag
 057b: cf 5f         xmit    FDC_DATA,ivr
 057c: cf 5a         xmit    CSR1,ivr
 057d: d9 20         xmit    0h,driv[6]
@@ -1818,12 +1845,12 @@ FDC_DATA     EQU  5fh
 0580: cf 5f x0580:  xmit    FDC_DATA,ivr
 0581: cf 5f         xmit    FDC_DATA,ivr
 0582: cf 5a x0582:  xmit    CSR1,ivr
-0583: be 22         nzt     sriv[1],x0582
+0583: be 22         nzt     sriv[1],x0582	; waiting for byte transfer flag
 0584: cf 5f         xmit    FDC_DATA,ivr
 0585: cf 5f         xmit    FDC_DATA,ivr
 0586: cf 5f         xmit    FDC_DATA,ivr
 0587: cf 5a x0587:  xmit    CSR1,ivr
-0588: be 27         nzt     sriv[1],x0587
+0588: be 27         nzt     sriv[1],x0587	; waiting for byte transfer flag
 0589: cf 5f         xmit    FDC_DATA,ivr
 058a: bf 0c         nzt     sriv,x058c
 058b: e5 8d         jmp     x058d
@@ -1831,21 +1858,21 @@ FDC_DATA     EQU  5fh
 058d: cf 5f x058d:  xmit    FDC_DATA,ivr
 058e: cf 5f         xmit    FDC_DATA,ivr
 058f: cf 5a x058f:  xmit    CSR1,ivr
-0590: be 2f         nzt     sriv[1],x058f
+0590: be 2f         nzt     sriv[1],x058f	; waiting for byte transfer flag
 0591: cf 5f         xmit    FDC_DATA,ivr
 0592: bf 17         nzt     sriv,x0597
 0593: cf 5b         xmit    CSR2,ivr
-0594: d9 21         xmit    1h,driv[6]
+0594: d9 21         xmit    1h,driv[6]		; set mode: disk write
 0595: c0 00         xmit    0h,aux
 0596: e7 b0         jmp     x07b0		; BIG RETURN
 0597: c0 07 x0597:  xmit    7h,aux
 0598: cf 5b         xmit    CSR2,ivr
-0599: d9 21         xmit    1h,driv[6]
+0599: d9 21         xmit    1h,driv[6]		; set mode: disk write
 059a: e4 a6         jmp     x04a6
 059b: 85 9c x059b:  xec     x059c,r5
 059c: e5 f1 x059c:  jmp     x05f1
 059d: e5 9e         jmp     x059e
-059e: c9 2c x059e:  xmit    2ch,r11			; r11 = 0x2c = 44
+059e: c9 2c x059e:  xmit    2ch,r11		; r11 = 0x2c = 44
 059f: e4 49         jmp     x0449
 05a0: a0 a2 x05a0:  nzt     aux,x05a2
 05a1: e5 a3         jmp     x05a3
@@ -1854,7 +1881,7 @@ FDC_DATA     EQU  5fh
 05a4: c2 fa         xmit    0fah,r2
 05a5: c0 01         xmit    1h,aux
 05a6: cf 02         xmit    HD_CMD,ivr
-05a7: c3 94         xmit    94h,r3
+05a7: c3 94         xmit    94h,r3		; HD_CMD = 0x94
 05a8: 03 1f         move    r3,driv
 05a9: 22 02 x05a9:  add     r2,r2
 05aa: a2 a9         nzt     r2,x05a9
@@ -1863,17 +1890,17 @@ FDC_DATA     EQU  5fh
 05ad: 00 00         nop     
 05ae: dd 20         xmit    0h,driv[2]
 05af: cf 03         xmit    HD_STATUS,ivr
-05b0: be 32 x05b0:  nzt     sriv[1],x05b2
+05b0: be 32 x05b0:  nzt     sriv[1],x05b2	; wait for 16Z
 05b1: e5 b0         jmp     x05b0
 05b2: c3 f7 x05b2:  xmit    0f7h,r3
 05b3: 23 03 x05b3:  add     r3,r3
 05b4: a3 b6         nzt     r3,x05b6
 05b5: e5 b9         jmp     x05b9
 05b6: bf 38 x05b6:  nzt     sriv[0],x05b8
-05b7: e5 b3         jmp     x05b3
+05b7: e5 b3         jmp     x05b3		; gap detected
 05b8: e5 9e x05b8:  jmp     x059e
 05b9: cf 02 x05b9:  xmit    HD_CMD,ivr
-05ba: c0 83         xmit    83h,aux
+05ba: c0 83         xmit    83h,aux		; HD_CMD = 0x83
 05bb: 00 1f         move    aux,driv
 05bc: cf 03         xmit    HD_STATUS,ivr
 05bd: e5 c0         jmp     x05c0
@@ -1881,8 +1908,8 @@ FDC_DATA     EQU  5fh
 05be: 00 00         nop     
 05bf: 00 00         nop     
 
-05c0: bd 23 x05c0:  nzt     sriv[2],x05c3
-05c1: be 20         nzt     sriv[1],x05c0
+05c0: bd 23 x05c0:  nzt     sriv[2],x05c3	; if AM, proceed
+05c1: be 20         nzt     sriv[1],x05c0	; if 16Z, keep waiting for AM
 05c2: e3 43         jmp     x0343
 05c3: cf 03 x05c3:  xmit    HD_STATUS,ivr
 05c4: bc 24 x05c4:  nzt     sriv[3],x05c4
@@ -1892,7 +1919,7 @@ FDC_DATA     EQU  5fh
 05c8: cf 01         xmit    DATA_PORT,ivr
 05c9: 7f 80         xor     sriv[3:0],aux
 05ca: cf 03         xmit    HD_STATUS,ivr
-05cb: a0 d2         nzt     aux,x05d2
+05cb: a0 d2         nzt     aux,x05d2		; DATA_PORT[3:0] != 8?
 05cc: bc 2c x05cc:  nzt     sriv[3],x05cc
 05cd: cf 01         xmit    DATA_PORT,ivr
 05ce: 1f 17         move    sriv,dliv
@@ -1906,7 +1933,7 @@ FDC_DATA     EQU  5fh
 05d6: 1f 17         move    sriv,dliv
 05d7: c7 ff         xmit    0ffh,ivl
 05d8: cf 03         xmit    HD_STATUS,ivr
-05d9: ba 34         nzt     sriv[5],x05d4
+05d9: ba 34         nzt     sriv[5],x05d4	; not full?
 05da: bc 3a x05da:  nzt     sriv[3],x05da
 05db: cf 01         xmit    DATA_PORT,ivr
 05dc: 1f 17         move    sriv,dliv
@@ -1919,32 +1946,32 @@ FDC_DATA     EQU  5fh
 05e1: bc 21 x05e1:  nzt     sriv[3],x05e1
 05e2: e7 8f         jmp     x078f
 05e3: cf 01 x05e3:  xmit    DATA_PORT,ivr
-05e4: bf 0f         nzt     sriv,x05ef
+05e4: bf 0f         nzt     sriv,x05ef		; DATA_PORT != 0?
 05e5: cf 03         xmit    HD_STATUS,ivr
 05e6: bc 26 x05e6:  nzt     sriv[3],x05e6
 05e7: cf 01         xmit    DATA_PORT,ivr
-05e8: bf 0f         nzt     sriv,x05ef
+05e8: bf 0f         nzt     sriv,x05ef		; DATA_PORT != 0?
 05e9: cf 02         xmit    HD_CMD,ivr
-05ea: df 20         xmit    0h,driv[0]
+05ea: df 20         xmit    0h,driv[0]		; clear RDGATE, resets zero detector
 05eb: de 20         xmit    0h,driv[1]
-05ec: c9 2d         xmit    2dh,r11			; r11 = 0x2d = 45
+05ec: c9 2d         xmit    2dh,r11		; r11 = 0x2d = 45
 05ed: e4 d5         jmp     x04d5
 05ee: e3 a5 x05ee:  jmp     x03a5
 05ef: c0 09 x05ef:  xmit    9h,aux
 05f0: e3 43         jmp     x0343
 05f1: cf 5b x05f1:  xmit    CSR2,ivr
 05f2: c2 40         xmit    40h,r2
-05f3: 02 1f         move    r2,driv
-05f4: c9 2e         xmit    2eh,r11			; r11 = 46
+05f3: 02 1f         move    r2,driv		; CSR2 = 0x40 (mode: disk write)
+05f4: c9 2e         xmit    2eh,r11		; r11 = 46
 05f5: e4 c4         jmp     x04c4
 05f6: c2 00 x05f6:  xmit    0h,r2
-05f7: c9 2f         xmit    2fh,r11			; r11 = 47
+05f7: c9 2f         xmit    2fh,r11		; r11 = 47
 05f8: e4 ee         jmp     x04ee
 05f9: a0 f1 x05f9:  nzt     aux,x05f1
-05fa: c9 30         xmit    30h,r11			; r11 = 48
+05fa: c9 30         xmit    30h,r11		; r11 = 48
 05fb: e7 7b         jmp     x077b
 05fc: c2 01 x05fc:  xmit    1h,r2
-05fd: c9 31         xmit    31h,r11			; r11 = 49
+05fd: c9 31         xmit    31h,r11		; r11 = 49
 05fe: e4 ee         jmp     x04ee
 05ff: a0 f1 x05ff:  nzt     aux,x05f1
 0600: cf 02         xmit    HD_CMD,ivr
@@ -1953,26 +1980,26 @@ FDC_DATA     EQU  5fh
 0603: cf 5f x0603:  xmit    FDC_DATA,ivr
 0604: cf 5f         xmit    FDC_DATA,ivr
 0605: cf 5a x0605:  xmit    CSR1,ivr
-0606: be 25         nzt     sriv[1],x0605
+0606: be 25         nzt     sriv[1],x0605	; waiting for byte transfer flag
 0607: cf 03         xmit    HD_STATUS,ivr
-0608: b9 2a         nzt     sriv[6],x060a
+0608: b9 2a         nzt     sriv[6],x060a	; DMA ACK?
 0609: e4 47         jmp     x0447
 060a: cf 5f x060a:  xmit    FDC_DATA,ivr
-060b: 1f 02         move    sriv,r2
+060b: 1f 02         move    sriv,r2		; floppy: get byte to transfer
 060c: cf 3f         xmit    DMA,ivr
-060d: 02 1f         move    r2,driv
+060d: 02 1f         move    r2,driv		; send to DMA
 060e: cf 02         xmit    HD_CMD,ivr
-060f: da 21         xmit    1h,driv[5]
+060f: da 21         xmit    1h,driv[5]		; trigger DMA Request
 0610: da 20         xmit    0h,driv[5]
 0611: cf 03         xmit    HD_STATUS,ivr
-0612: ba 34         nzt     sriv[5],x0614
+0612: ba 34         nzt     sriv[5],x0614	; not full?
 0613: e6 16         jmp     x0616
 0614: c7 ff x0614:  xmit    0ffh,ivl
 0615: e6 03         jmp     x0603
 0616: cf 5f x0616:  xmit    FDC_DATA,ivr
 0617: cf 5f         xmit    FDC_DATA,ivr
 0618: cf 5a x0618:  xmit    CSR1,ivr
-0619: be 38         nzt     sriv[1],x0618
+0619: be 38         nzt     sriv[1],x0618	; waiting for byte transfer flag
 061a: cf 5f         xmit    FDC_DATA,ivr
 061b: cf 5a         xmit    CSR1,ivr
 061c: d9 20         xmit    0h,driv[6]
@@ -1984,30 +2011,33 @@ FDC_DATA     EQU  5fh
 0620: cf 5f x0620:  xmit    FDC_DATA,ivr
 0621: cf 5f         xmit    FDC_DATA,ivr
 0622: cf 5a x0622:  xmit    CSR1,ivr
-0623: be 22         nzt     sriv[1],x0622
+0623: be 22         nzt     sriv[1],x0622	; waiting for byte transfer flag
 0624: cf 5f         xmit    FDC_DATA,ivr
 0625: cf 5f         xmit    FDC_DATA,ivr
 0626: cf 5f         xmit    FDC_DATA,ivr
 0627: cf 5a x0627:  xmit    CSR1,ivr
-0628: be 27         nzt     sriv[1],x0627
+0628: be 27         nzt     sriv[1],x0627	; waiting for byte transfer flag
 0629: cf 5f         xmit    FDC_DATA,ivr
-062a: bf 15         nzt     sriv,x0635
+062a: bf 15         nzt     sriv,x0635		; floppy byte not zero?
 062b: cf 5f         xmit    FDC_DATA,ivr
 062c: cf 5f         xmit    FDC_DATA,ivr
 062d: cf 5a x062d:  xmit    CSR1,ivr
-062e: be 2d         nzt     sriv[1],x062d
+062e: be 2d         nzt     sriv[1],x062d	; waiting for byte transfer flag
 062f: cf 5f         xmit    FDC_DATA,ivr
-0630: bf 15         nzt     sriv,x0635
+0630: bf 15         nzt     sriv,x0635		; floppy byte not zero?
 0631: c2 40         xmit    40h,r2
 0632: cf 5b         xmit    CSR2,ivr
-0633: 02 1f         move    r2,driv
+0633: 02 1f         move    r2,driv		; CSR2 = 0x40 (mode: disk write)
 0634: e4 36         jmp     x0436
 0635: e5 ef x0635:  jmp     x05ef
+
+; set head select
+
 0636: c0 00 x0636:  xmit    0h,aux
 0637: cf 4b         xmit    VAL_3,ivr
 0638: 00 7b         move    aux,driv[6:4]
 0639: cf 5c         xmit    CSR3,ivr
-063a: 00 7e         move    aux,driv[3:1]
+063a: 00 7e         move    aux,driv[3:1]	; head select = VAL_3[6:4]
 063b: cf 4c         xmit    VAL_4,ivr
 063c: e3 bc         jmp     x03bc
 
@@ -2039,11 +2069,11 @@ FDC_DATA     EQU  5fh
 
 0646: cf 5a x0646:  xmit    CSR1,ivr
 0647: c0 00         xmit    0h,aux		; aux = 0
-0648: bf 2a         nzt     sriv[0],x064a
+0648: bf 2a         nzt     sriv[0],x064a	; READY?
 0649: e7 b0         jmp     x07b0		; BIG RETURN
 
 064a: cf 5a x064a:  xmit    CSR1,ivr
-064b: bf 2d         nzt     sriv[0],x064d
+064b: bf 2d         nzt     sriv[0],x064d	; READY?
 064c: e6 46         jmp     x0646		; loop (sort of)
 
 064d: c0 02 x064d:  xmit    2h,aux		; aux = 2
@@ -2056,22 +2086,22 @@ FDC_DATA     EQU  5fh
 0650: cf 51         xmit    VAL_9,ivr
 0651: df 00         xmit    0h,driv
 0652: cf 5d         xmit    CSR4,ivr
-0653: 18 21         move    sriv[7],r1
+0653: 18 21         move    sriv[7],r1		; r1 = track0
 0654: 21 01         add     r1,r1
 0655: cf 51         xmit    VAL_9,ivr
 0656: 01 3b         move    r1,driv[4]
 0657: cf 5d         xmit    CSR4,ivr
-0658: 1a 21         move    sriv[5],r1
+0658: 1a 21         move    sriv[5],r1		; r1 = write protect
 0659: 21 01         add     r1,r1
 065a: cf 51         xmit    VAL_9,ivr
 065b: 01 39         move    r1,driv[6]
 065c: cf 5d         xmit    CSR4,ivr
-065d: 1b 21         move    sriv[4],r1
+065d: 1b 21         move    sriv[4],r1		; r1 = seek complete
 065e: 21 01         add     r1,r1
 065f: cf 51         xmit    VAL_9,ivr
 0660: 01 3c         move    r1,driv[3]
 0661: cf 5a         xmit    CSR1,ivr
-0662: 1f 21         move    sriv[0],r1
+0662: 1f 21         move    sriv[0],r1		; r1 = READY
 0663: 21 01         add     r1,r1
 0664: cf 51         xmit    VAL_9,ivr
 0665: 01 3a         move    r1,driv[5]
@@ -2145,17 +2175,17 @@ FDC_DATA     EQU  5fh
 0699: 04 0f         move    r4,ivr		; access 0x48 or 0x49
 069a: 1f 02         move    sriv,r2		; read it to r2
 069b: cf 4c         xmit    VAL_4,ivr
-069c: 1f 01         move    sriv,r1		; read VAL_4 to r1
+069c: 1f 01         move    sriv,r1		; r1 = track number
 
 ; xor with a mask of all ones inverts the bits
 
 069d: c0 ff         xmit    0ffh,aux
 069e: 62 03         xor     r2,r3		; r3 = ~r2
 069f: c0 01         xmit    1h,aux		; aux = 1
-06a0: 23 00         add     r3,aux
+06a0: 23 00         add     r3,aux		; aux = two's complement of r2
 06a1: 08 02         move    ovf,r2
-06a2: 21 03         add     r1,r3
-06a3: a3 a5         nzt     r3,x06a5
+06a2: 21 03         add     r1,r3		; r3 = track number + two's comp of r2
+06a3: a3 a5         nzt     r3,x06a5		; have we reached the target track number? (?)
 06a4: e7 1a         jmp     x071a		; go to wrap up
 
 06a5: cf 5c x06a5:  xmit    CSR3,ivr
@@ -2327,7 +2357,7 @@ FDC_DATA     EQU  5fh
 0725: e7 60         jmp     x0760
 
 0726: cf 4c x0726:  xmit    VAL_4,ivr
-0727: 1f 04         move    sriv,r4
+0727: 1f 04         move    sriv,r4		; r4 = track number
 0728: c0 48         xmit    48h,aux
 0729: 25 0f         add     r5,ivr
 072a: 04 1f         move    r4,driv		; {48,49} = r4
@@ -2378,7 +2408,7 @@ FDC_DATA     EQU  5fh
 0742: cf 3e         xmit    M_STATUS,ivr
 0743: 00 3a         move    aux,driv[5]
 0744: cf 02         xmit    HD_CMD,ivr
-0745: 00 39         move    aux,driv[6]
+0745: 00 39         move    aux,driv[6]		; trigger INT6 if VAL2 sriv[1:0] != 0
 0746: e7 b0         jmp     x07b0		; BIG RETURN
 
 0747: c0 00 x0747:  xmit    0h,aux
@@ -2414,7 +2444,7 @@ FDC_DATA     EQU  5fh
 
 0758: cf 50 x0758:  xmit    VAL_8,ivr
 0759: c0 01         xmit    1h,aux
-075a: 3f 1f         add     sriv,driv
+075a: 3f 1f         add     sriv,driv		; VAL_8++
 075b: cf 50         xmit    VAL_8,ivr
 075c: bf 1f         nzt     sriv,x075f
 075d: c0 04         xmit    4h,aux
@@ -2431,14 +2461,14 @@ FDC_DATA     EQU  5fh
 0768: c0 01 x0768:  xmit    1h,aux
 0769: c1 80         xmit    80h,r1
 076a: 21 01 x076a:  add     r1,r1
-076b: a1 6a         nzt     r1,x076a
+076b: a1 6a         nzt     r1,x076a		; delay loop (128 times)
 076c: e7 b0 x076c:  jmp     x07b0		; BIG RETURN
 
 076d: cf 5a x076d:  xmit    CSR1,ivr
-076e: bf 30         nzt     sriv[0],x0770
+076e: bf 30         nzt     sriv[0],x0770	; check READY
 076f: e4 fb         jmp     x04fb
 0770: cf 5b x0770:  xmit    CSR2,ivr
-0771: d9 21         xmit    1h,driv[6]
+0771: d9 21         xmit    1h,driv[6]		; set mode: disk write
 0772: e2 24         jmp     x0224
 0773: c0 01 x0773:  xmit    1h,aux
 0774: c1 00         xmit    0h,r1
@@ -2449,14 +2479,14 @@ FDC_DATA     EQU  5fh
 0779: a2 76         nzt     r2,x0776
 077a: e1 4b         jmp     x014b
 077b: cf 5b x077b:  xmit    CSR2,ivr
-077c: d9 21         xmit    1h,driv[6]
+077c: d9 21         xmit    1h,driv[6]		; set mode: disk write
 077d: c2 ee         xmit    0eeh,r2
 077e: c0 01 x077e:  xmit    1h,aux
 077f: e7 80         jmp     x0780
 0780: cf 5f x0780:  xmit    FDC_DATA,ivr
 0781: cf 5f         xmit    FDC_DATA,ivr
 0782: cf 5a x0782:  xmit    CSR1,ivr
-0783: be 22         nzt     sriv[1],x0782
+0783: be 22         nzt     sriv[1],x0782	; waiting for byte transfer flag
 0784: cf 5f         xmit    FDC_DATA,ivr
 0785: 22 02         add     r2,r2
 0786: a2 7e         nzt     r2,x077e


### PR DESCRIPTION
Hey Tom. I have been helping AJ Palmgren diagnose an issue with his AWS machines where floppy data gets funky at Track 43 and beyond. My theory was precompensation was kicking in around there and sure enough I was able to find the "precomp enable" in your disassembly for track >= 43. I then went down the rabbit hole learning about Signetics assembly (from your summary) and commenting other things I found looking into all this. So here's some additional comments on the disassembly. Still plenty of puzzles to dissect, but at least a little more info. 

It's been interesting learning about Signetics assembly, and helpful for investigation into AJ's issue, so thanks!  

Jesse